### PR TITLE
Fix Ausgabe und zähle Kanten zu sich selbst richtig

### DIFF
--- a/src/org/asysob/Graph.java
+++ b/src/org/asysob/Graph.java
@@ -22,7 +22,14 @@ class Graph implements IGraph {
     public int edgeCount () {
         int sum = 0;
         for (HashMap.Entry<Integer,Set<Integer>> entry : graph.entrySet())
-            sum += entry.getValue().size();
+        	for(Integer target: entry.getValue()){
+        		if(target != entry.getKey()){
+        			sum ++;
+        		}else{
+        			sum +=2;
+        		}
+        	}
+            
         return sum/2;
     }
 

--- a/src/org/asysob/Graph.java
+++ b/src/org/asysob/Graph.java
@@ -66,9 +66,9 @@ class Graph implements IGraph {
         out.print("\tEdges");
         for (HashMap.Entry<Integer,Set<Integer>> entry : graph.entrySet()) {
             for (Integer n : entry.getValue())
-                if (entry.getKey() < n) {
-                    out.print(" <"+entry.getKey()+","+n+">");
-                }
+            	if(entry.getKey() <= n){
+            		out.print(" <"+entry.getKey()+","+n+">");
+            	}
         }
         out.println();
         out.println("}");


### PR DESCRIPTION
Jetzt aber. edgeCount war natürlich auch falsch, da eine Kante von v nach v nur einmal gezählt aber dann geteilt wurde. 
